### PR TITLE
Expose ctrl,shift,alt to map event

### DIFF
--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -655,7 +655,12 @@ _htmlwidgets2.default.widget({
               _shiny2.default.onInputChange(map.id + "_click", {
                 lat: e.latlng.lat,
                 lng: e.latlng.lng,
-                ".nonce": Math.random() // Force reactivity if lat/lng hasn't changed
+                ".nonce": Math.random(), // Force reactivity if lat/lng hasn't changed
+                modifiers: {
+                  ctrl: e.originalEvent.ctrlKey,
+                  shift: e.originalEvent.shiftKey,
+                  alt: e.originalEvent.altKey
+                }
               });
             });
 
@@ -1352,7 +1357,12 @@ function mouseHandler(mapId, layerId, group, eventName, extraInfo) {
     }
     var eventInfo = _jquery2.default.extend({
       id: layerId,
-      ".nonce": Math.random() // force reactivity
+      ".nonce": Math.random(), // force reactivity
+      modifiers: {
+        ctrl: e.originalEvent.ctrlKey,
+        shift: e.originalEvent.shiftKey,
+        alt: e.originalEvent.altKey
+      }
     }, group !== null ? { group: group } : null, latLng, extraInfo);
 
     _shiny2.default.onInputChange(mapId + "_" + eventName, eventInfo);

--- a/javascript/src/index.js
+++ b/javascript/src/index.js
@@ -140,7 +140,13 @@ HTMLWidgets.widget({
             Shiny.onInputChange(map.id + "_click", {
               lat: e.latlng.lat,
               lng: e.latlng.lng,
-              ".nonce": Math.random() // Force reactivity if lat/lng hasn't changed
+              ".nonce": Math.random(), // Force reactivity if lat/lng hasn't changed
+              modifiers: {
+                alt: e.originalEvent.altKey,
+                ctrl: e.originalEvent.ctrlKey,
+                meta: e.originalEvent.metaKey,
+                shift: e.originalEvent.shiftKey
+              }
             });
           });
 

--- a/javascript/src/methods.js
+++ b/javascript/src/methods.js
@@ -81,7 +81,12 @@ function mouseHandler(mapId, layerId, group, eventName, extraInfo) {
     let eventInfo = $.extend(
       {
         id: layerId,
-        ".nonce": Math.random()  // force reactivity
+        ".nonce": Math.random(),  // force reactivity
+        modifiers: {
+          ctrl: e.originalEvent.ctrlKey,
+          shift: e.originalEvent.shiftKey,
+          alt: e.originalEvent.altKey
+        }
       },
       group !== null ? {group: group} : null,
       latLng,


### PR DESCRIPTION
Minor change to enable detection of modifier keys on map click. 

Couldn't figure out how to attach to `map_shape_click` so instead this uses `map_click`, but still seems to work as both events are fired anyway 